### PR TITLE
Add script converting Excel CSV to UTF-8 encoding

### DIFF
--- a/excel-csv-to-utf8.py
+++ b/excel-csv-to-utf8.py
@@ -1,0 +1,17 @@
+__author__ = 'mmaks'
+"""
+Скрипт для перевода CSV-выгрузки из Excel в кодировку UTF-8.
+Скрипт запускается из папки с данными, итерирует по всем файлам в ней (кроме .py и скрытых) и сохраняет копии файлов в UTF-8 в соседнюю папку "data-encoded"
+"""
+
+import os
+
+os.mkdir('../data-encoded')
+for filename in os.listdir(os.getcwd()):
+    if filename.startswith(".") or filename.endswith(".py"):
+        continue
+    print(filename)
+    with open(filename, 'r', encoding='windows-1251') as sourceFile:
+        with open('../data-encoded/' + filename, 'w', encoding='utf-8') as resultFile:
+            for line in sourceFile:
+                resultFile.write(line)


### PR DESCRIPTION
When you ’Save as CSV’ from Excel, the result has windows-1251 encoding
(aka ‘ansi’), which is meaningless for most software, especially on
Mac. The quickest way to deal with this problem is to convert the data
to UTF-8. This script iterates through all the files in its working
directory, encodes them to UTF-8 and saves the correctly encoded copies
to adjacent ‘data-encoded’ folder.
